### PR TITLE
Fix rad and wid to round up the result.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ❗ indicates an breaking change.
 
+## Unreleased
+
+### Fixed
+
+- Fix `rad` and `wid` methods that were not rounding the result up.
+
 ## v0.2.0 - 2020-07-09
 
 ### Added

--- a/src/numeric.rs
+++ b/src/numeric.rs
@@ -56,7 +56,10 @@ impl Interval {
     pub fn rad(self) -> f64 {
         let m = self.mid();
         let _r = RoundUpContext::new();
-        f64::max(m - self.inf_raw(), self.sup_raw() - m)
+        f64::max(
+            secure(secure(m) - secure(self.inf_raw())),
+            secure((self.sup_raw()) - secure(m)),
+        )
     }
 
     pub fn sup(self) -> f64 {
@@ -73,7 +76,7 @@ impl Interval {
 
     pub fn wid(self) -> f64 {
         let _r = RoundUpContext::new();
-        let wid = self.sup_raw() - self.inf_raw();
+        let wid = secure(secure(self.sup_raw()) - secure(self.inf_raw()));
         if wid == 0.0 {
             0.0
         } else {

--- a/src/numeric.rs
+++ b/src/numeric.rs
@@ -55,6 +55,7 @@ impl Interval {
 
     pub fn rad(self) -> f64 {
         let m = self.mid();
+        let _r = RoundUpContext::new();
         f64::max(m - self.inf_raw(), self.sup_raw() - m)
     }
 
@@ -71,6 +72,7 @@ impl Interval {
     }
 
     pub fn wid(self) -> f64 {
+        let _r = RoundUpContext::new();
         let wid = self.sup_raw() - self.inf_raw();
         if wid == 0.0 {
             0.0
@@ -160,5 +162,11 @@ mod tests {
         assert!(interval!(0.0, -0.0).unwrap().wid().is_sign_positive());
         assert!(interval!(-0.0, 0.0).unwrap().wid().is_sign_positive());
         assert!(interval!(-0.0, -0.0).unwrap().wid().is_sign_positive());
+
+        // Check if the result is rounded up.
+        assert_eq!(
+            interval!(-f64::MIN_POSITIVE, f64::MAX).unwrap().wid(),
+            f64::INFINITY
+        );
     }
 }


### PR DESCRIPTION
## Note

- I couldn't find an example that proves `rad` was broken. Maybe it wasn't?